### PR TITLE
added missing settings compared to maven plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ buildscript {
 		maven { url "http://google-diff-match-patch.googlecode.com/svn/trunk/maven" }
 	}
 	dependencies {
-		classpath('org.jsweet:jsweet-gradle-plugin:1.0.0-SNAPSHOT') { //
+		classpath('org.jsweet:jsweet-gradle-plugin:1.2.1-SNAPSHOT') { //
 			transitive = true }
 	}
 }
@@ -52,7 +52,7 @@ jsweet {
 	encoding = 'UTF-8'
 	sourceMap = true
 	outDir = new File('target/js')
-	targetVersion = EcmaScriptComplianceLevel.ES3
+	targetVersion = 'ES3'
 	includes = ['**/fr/test/my/**/*.java']
 }
 
@@ -66,11 +66,13 @@ targetVersion | enum | ES3, ES5, ES6 | ES3 | ``` jsweet { targetVersion = EcmaSc
 module | enum | commonjs, amd, system, umd | none | ``` jsweet { module = ModuleKind.commonjs } ```
 outDir | File | JS files output directory | .jsweet/js | ```jsweet { outDir = new File('target/js') }```
 tsOut | File | Temporary TypeScript output directory | .jsweet/ts | ```jsweet { tsOut = new File('target/ts') }```
+tsOnly | boolean | If true, JSweet will not generate any JavaScript | false | ```jsweet { tsOnly = true }```
 includes | string[] | Java source files to be included | N/A | ```jsweet { includes = ['**/org/jsweet/examples/**/*.java', '**/other/*] }```
 excludes | string[] | Source files to be excluded | N/A | ```jsweet { excludes = ['**/excluded/**/*.java'] }```
 bundle | boolean | Concats all JS file into one bundle | false |   ```jsweet { bundle = true }```
 bundlesDirectory | File | JS bundles output directory | N/A | ```jsweet { bundlesDirectory = new File('target/js/bundles') }```
 sourceMap | boolean | In-browser debug mode - true for java, typescript else | true | ```jsweet { javaDebug = true }```
+sourceRoot | string | The location where debugger should locate Java files instead of source locations | N/A | ```jsweet { sourceRoot = new File('src') }```
 encoding | string | Java files encoding | UTF-8 | ```jsweet { encoding = 'UTF-8' }```
 noRootDirectories | boolean | output is relative to @jsweet.lang.Root package's directories | false | ```jsweet { noRootDirectories = true }```
 enableAssertions | boolean | assert are transpiled as JS check | false | ```jsweet { enableAssertions = true }```
@@ -79,6 +81,9 @@ jdkHome | File | Alternative JDK >= 8 directory, for instance if running Maven w
 declaration | boolean | Generates TypeScript d.ts | false | ```jsweet { declaration = true }```
 dtsOut | File | TypeScript d.ts output directory when the declaration option is true | outDir | ```jsweet { dtsOut = new File('typings') }```
 candiesJsOut | File | Directory where to extract candies' Javascript |  | ```candiesJsOut { jdkHome = new File('www/js/candies') }```
+definitions | boolean | Generates definitions from def.* packages in d.ts definition files, in the tsOut directory (do not confuse with the 'declaration' option) | true | ```jsweet { definitions = true }```
+disableJavaAddons | boolean | Disables Java-specific code generation behavior (for advanced users only) | false | ```jsweet { disableJavaAddons = true }```
+
 
 Then, just invoke one of the JSweet gradle task:
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'maven-publish'
 apply plugin: 'maven-publish-auth'
 
 group = 'org.jsweet'
-version = '1.2.0-SNAPSHOT'
+version = '1.2.1-SNAPSHOT'
 description = 'JSweet Gradle plugin'
 
 sourceCompatibility = 1.8
@@ -75,5 +75,5 @@ publishing {
 	}
 }
 task wrapper(type: Wrapper) {
-	gradleVersion = '2.10'
+	gradleVersion = '3.3'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-bin.zip

--- a/src/main/java/org/jsweet/gradle/JSweetPluginExtension.java
+++ b/src/main/java/org/jsweet/gradle/JSweetPluginExtension.java
@@ -59,6 +59,14 @@ public class JSweetPluginExtension {
 		this.tsOut = tsOut;
 	}
 
+	public boolean isTsOnly() {
+		return tsOnly;
+	}
+	
+	public void setTsOnly(boolean tsOnly) {
+		this.tsOnly = tsOnly;
+	}
+	
 	public String[] getIncludes() {
 		return includes;
 	}
@@ -97,6 +105,14 @@ public class JSweetPluginExtension {
 
 	public void setSourceMap(boolean sourceMaps) {
 		this.sourceMap = sourceMaps;
+	}
+	
+	public File getSourceRoot() {
+		return sourceRoot;
+	}
+	
+	public void setSourceRoot(File sourceRoot) {
+		this.sourceRoot = sourceRoot;
 	}
 
 	public String getEncoding() {
@@ -163,16 +179,34 @@ public class JSweetPluginExtension {
 		this.candiesJsOut = candiesJsOut;
 	}
 
+	public boolean isDefinitions() {
+		return definitions;
+	}
+	
+	public void setDefinitions(boolean definitions) {
+		this.definitions = definitions;
+	}
+	
+	public boolean isDisableJavaAddons() {
+		return disableJavaAddons;
+	}
+	
+	public void setDisableJavaAddons(boolean disableJavaAddons) {
+		this.disableJavaAddons = disableJavaAddons;
+	}
+	
 	private EcmaScriptComplianceLevel targetVersion = EcmaScriptComplianceLevel.ES3;
 	private ModuleKind module = ModuleKind.none;
 	private File outDir = new File("js");
 	private File tsOut = new File(".ts");
+	private boolean tsOnly = false;
 	private String[] includes = null;
 	private String[] excludes = null;
 	private boolean bundle = false;
 	private File bundlesDirectory = null;
 
 	private boolean sourceMap = false;
+	private File sourceRoot = null;
 	private String encoding = "UTF-8";
 
 	private boolean noRootDirectories = false;
@@ -186,4 +220,6 @@ public class JSweetPluginExtension {
 	private boolean declaration;
 	private File dtsOut;
 	private File candiesJsOut;
+	private boolean definitions=true;
+	private boolean disableJavaAddons=false;
 }

--- a/src/main/java/org/jsweet/gradle/JSweetTranspileTask.java
+++ b/src/main/java/org/jsweet/gradle/JSweetTranspileTask.java
@@ -91,6 +91,7 @@ public class JSweetTranspileTask extends AbstractJSweetTask {
 			logInfo("ts output dir: " + tsOutputDir);
 			logInfo("js output dir: " + jsOutputDir);
 
+			logInfo("ts only: "+configuration.isTsOnly());
 			logInfo("declarations: " + configuration.isDeclaration());
 			logInfo("declarationOutDir: " + configuration.getDtsOut());
 			logInfo("candiesJsOutDir: " + configuration.getCandiesJsOut());
@@ -102,19 +103,26 @@ public class JSweetTranspileTask extends AbstractJSweetTask {
 			logInfo("ecmaTargetVersion: " + configuration.getTargetVersion());
 			logInfo("moduleKind: " + configuration.getModule());
 			logInfo("sourceMaps: " + configuration.isSourceMap());
+			logInfo("SourceRoot: "+configuration.getSourceRoot());
 			logInfo("jdkHome: " + jdkHome);
-
+			logInfo("definitions: "+configuration.isDefinitions());
+			logInfo("disableJavaAddons: "+configuration.isDisableJavaAddons());
+			
 			SourceFile[] sourceFiles = collectSourceFiles();
 
 			JSweetTranspiler transpiler = new JSweetTranspiler(tsOutputDir, jsOutputDir,
 					configuration.getCandiesJsOut(), classpath.getAsPath());
 
 			transpiler.setTscWatchMode(false);
+			transpiler.setGenerateJsFiles(!configuration.isTsOnly());
 			transpiler.setEcmaTargetVersion(configuration.getTargetVersion());
 			transpiler.setModuleKind(configuration.getModule());
 			transpiler.setBundle(configuration.isBundle());
 			transpiler.setBundlesDirectory(bundlesDirectory);
 			transpiler.setPreserveSourceLineNumbers(configuration.isSourceMap());
+			if(configuration.getSourceRoot() != null) {
+				transpiler.setSourceRoot(configuration.getSourceRoot());
+			}
 
 			transpiler.setEncoding(configuration.getEncoding());
 			transpiler.setNoRootDirectories(configuration.isNoRootDirectories());
@@ -122,6 +130,10 @@ public class JSweetTranspileTask extends AbstractJSweetTask {
 
 			transpiler.setGenerateDeclarations(configuration.isDeclaration());
 			transpiler.setDeclarationsOutputDir(configuration.getDtsOut());
+			transpiler.setGenerateDefinitions(configuration.isDefinitions());
+			transpiler.setInterfaceTracking(!configuration.isDisableJavaAddons());
+			transpiler.setSupportGetClass(!configuration.isDisableJavaAddons());
+			transpiler.setSupportSaticLazyInitialization(!configuration.isDisableJavaAddons());
 
 			transpiler.transpile(transpilationHandler, sourceFiles);
 		} catch (NoClassDefFoundError e) {


### PR DESCRIPTION
I have added 4 missing settings compared to maven plugin:
**tsOnly**: To generate only typescript files (required for angular2 codes)
**sourceRoot**: To set source root for debugger
**definitions**: To generate t.ds files from def.* 
**disableJavaAddons**: To replace JavaSpecific APIs where possible