### PR TITLE
jsweet task now depends on 'compileJava' rather than 'classes'.

### DIFF
--- a/src/main/java/org/jsweet/gradle/JSweetPlugin.java
+++ b/src/main/java/org/jsweet/gradle/JSweetPlugin.java
@@ -49,6 +49,8 @@ public class JSweetPlugin implements Plugin<Project> {
 		SourceSet mainSources = sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME);
 
 		JSweetTranspileTask task = project.getTasks().create("jsweet", JSweetTranspileTask.class);
+		task.setGroup("generate");
+		task.dependsOn(JavaPlugin.COMPILE_JAVA_TASK_NAME);
 		task.setConfiguration(extension);
 		task.setSources(mainSources.getAllJava());
 		task.setClasspath(mainSources.getCompileClasspath());

--- a/src/main/java/org/jsweet/gradle/JSweetTranspileTask.java
+++ b/src/main/java/org/jsweet/gradle/JSweetTranspileTask.java
@@ -47,11 +47,6 @@ import org.jsweet.transpiler.util.ProcessUtil;
  */
 public class JSweetTranspileTask extends AbstractJSweetTask {
 
-	public JSweetTranspileTask() {
-		dependsOn(JavaPlugin.CLASSES_TASK_NAME);
-		setGroup("generate");
-	}
-
 	private SourceDirectorySet sources;
 	private FileCollection classpath;
 


### PR DESCRIPTION
Closes #15.