### PR TITLE
Support a specific "jsweet" source set

### DIFF
--- a/src/main/java/org/jsweet/gradle/JSweetPlugin.java
+++ b/src/main/java/org/jsweet/gradle/JSweetPlugin.java
@@ -47,6 +47,9 @@ public class JSweetPlugin implements Plugin<Project> {
 		JavaPluginConvention javaPluginConvention = project.getConvention().getPlugin(JavaPluginConvention.class);
 		SourceSetContainer sourceSets = javaPluginConvention.getSourceSets();
 		SourceSet mainSources = sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME);
+		if (sourceSets.getNames().contains("jsweet")) {
+			mainSources = sourceSets.getByName("jsweet");
+		}
 
 		JSweetTranspileTask task = project.getTasks().create("jsweet", JSweetTranspileTask.class);
 		task.setGroup("generate");


### PR DESCRIPTION
Addresses https://github.com/lgrignon/jsweet-gradle-plugin/issues/22

This allowed me to have sources for my JSweet transpile task that are NOT considered for my normal Java compile task.  This is important because most of the Java code continues to be used in a desktop app, but a few classes are added (and many excluded) to build an adapter layer for use in Javascript.