### PR TITLE
update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,16 @@ Add the JSweet's repositories and the Gradle plugin dependency to your project's
 buildscript {
 	repositories {
 		mavenCentral()
-		maven { url "http://repository.jsweet.org/artifactory/libs-release-local" }
-		maven { url "http://repository.jsweet.org/artifactory/libs-snapshot-local" }
-		maven { url "http://repository.jsweet.org/artifactory/plugins-release-local" }
-		maven { url "http://repository.jsweet.org/artifactory/plugins-snapshot-local" }
-		maven { url "http://google-diff-match-patch.googlecode.com/svn/trunk/maven" }
+		maven { url "https://repository.jsweet.org/artifactory/libs-release-local" }
+		maven { url "https://repository.jsweet.org/artifactory/libs-snapshot-local" }
+		maven { url "https://repository.jsweet.org/artifactory/plugins-release-local" }
+		maven { url "https://repository.jsweet.org/artifactory/plugins-snapshot-local" }
+		maven { url "https://google-diff-match-patch.googlecode.com/svn/trunk/maven" }
 	}
 	dependencies {
-		classpath('org.jsweet:jsweet-gradle-plugin:3.0.0') { //
-			transitive = true }
+		classpath('org.jsweet:jsweet-gradle-plugin:3.1.0') {
+			transitive = true 
+		}
 	}
 }
 ```


### PR DESCRIPTION
The http resolver urls cause this exception:

```
FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring root project 'jsweet-test'.
> Could not resolve all dependencies for configuration ':classpath'.
   > Using insecure protocols with repositories, without explicit opt-in, is unsupported. Switch Maven repository 'maven(http://repository.jsweet.org/artifactory/libs-release-local)' to redirect to a secure protocol (like HTTPS) or allow insecure protocols. See https://docs.gradle.org/7.2/dsl/org.gradle.api.artifacts.repositories.UrlArtifactRepository.html#org.gradle.api.artifacts.repositories.UrlArtifactRepository:allowInsecureProtocol for more details.
```

Using 3.0.0 causes this:

```
A problem occurred configuring root project 'jsweet-test'.
> java.util.concurrent.ExecutionException: org.gradle.api.GradleException: Failed to create Jar file /Users/josephprice/.gradle/caches/jars-9/b4e0848c0dcdf15e546dced29a281ac6/jsweet-transpiler-3.0.0.jar.
```